### PR TITLE
Optimize Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.15
+FROM alpine:3.15 AS build
 
-RUN apk add --no-cache coreutils curl jq gfortran libc-dev cmake make python3 git
+RUN apk add --no-cache curl
 
 WORKDIR /opt/test-runner/testlib
 RUN curl -R -O https://raw.githubusercontent.com/exercism/fortran/main/testlib/CMakeLists.txt
@@ -8,6 +8,13 @@ RUN curl -R -O https://raw.githubusercontent.com/exercism/fortran/main/testlib/T
 
 WORKDIR /opt/test-runner
 RUN curl -R -O https://raw.githubusercontent.com/exercism/fortran/main/config/CMakeLists.txt
+
+FROM alpine:3.15
+
+RUN apk add --no-cache coreutils jq gfortran libc-dev cmake make
+
+WORKDIR /opt/test-runner
+COPY --from=build /opt/test-runner/ .
 
 COPY . .
 ENTRYPOINT ["/opt/test-runner/bin/run.sh"]


### PR DESCRIPTION
The curl, python3 and git dependencies are no longer present in the built image.

Besides the security benefit, it also reduces the image size from 271MB to 215MB.
