### PR TITLE
Add a file to bust the Docker cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM alpine:3.15 AS build
 
 RUN apk add --no-cache curl
 
+WORKDIR /opt/test-runner
+COPY bust_cache .
+
 WORKDIR /opt/test-runner/testlib
 RUN curl -R -O https://raw.githubusercontent.com/exercism/fortran/main/testlib/CMakeLists.txt
 RUN curl -R -O https://raw.githubusercontent.com/exercism/fortran/main/testlib/TesterMain.f90

--- a/bust_cache
+++ b/bust_cache
@@ -1,0 +1,5 @@
+After making changes to `TesterMain.f90` in the Fortran track repo, increment
+below to bust the Docker cache so that tests in the editor can use the latest
+version of the test module.
+
+0


### PR DESCRIPTION
Added a file that can be changed to bust the Docker cache, as suggest in [this forum post](http://forum.exercism.org/t/editor-doesnt-use-latest-version-of-test-module/6700/5). This is intended to resolve exercism/fortran#228.